### PR TITLE
Implement basic gamified learning scaffolds

### DIFF
--- a/blueprint.md
+++ b/blueprint.md
@@ -1,3 +1,11 @@
+## Overview
+
+Cross-platform gamified learning app inspired by Duolingo. Core modules include:
+* User authentication and profiles with progress tracking.
+* Admin dashboard to upload learning materials that trigger Vertex AI to create lessons and quizzes.
+* Gamified course map, quizzes, streaks and XP with leaderboard.
+* Progressive Web App support and Firebase integration.
+
 ### Firestore Data Schema
 
 *   **users (collection)**:
@@ -158,3 +166,11 @@ export const processUploadedContent = functions.storage.object().onFinalize(asyn
 3.  **Deploy:** Navigate to your project directory and run `vercel`. Follow the prompts to configure and deploy your project.
 
 Remember to set up your Firebase environment variables (e.g., `NEXT_PUBLIC_FIREBASE_API_KEY`) in your hosting provider's settings.
+
+### Current Plan
+
+* Scaffold reusable React components for course map, quiz, leaderboard and profile dashboard.
+* Provide example Cloud Function using Vertex AI for automatic lesson generation.
+* Add Firebase security rules enforcing admin-only writes to course content.
+* Stub admin upload page that uploads files to Cloud Storage which triggers the function.
+* Add placeholder pages demonstrating leaderboard and lesson quizzes.

--- a/components/CourseMap.tsx
+++ b/components/CourseMap.tsx
@@ -1,0 +1,30 @@
+"use client";
+import React from "react";
+
+export interface LessonNode {
+  id: string;
+  title: string;
+  unlocked: boolean;
+}
+
+interface CourseMapProps {
+  lessons: LessonNode[];
+  onSelect: (id: string) => void;
+}
+
+export default function CourseMap({ lessons, onSelect }: CourseMapProps) {
+  return (
+    <div className="flex flex-wrap gap-4">
+      {lessons.map((lesson) => (
+        <button
+          key={lesson.id}
+          disabled={!lesson.unlocked}
+          className="p-4 border rounded disabled:opacity-50"
+          onClick={() => onSelect(lesson.id)}
+        >
+          {lesson.title}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/components/Leaderboard.tsx
+++ b/components/Leaderboard.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+
+export interface LeaderboardEntry {
+  userId: string;
+  displayName: string;
+  xp: number;
+}
+
+interface LeaderboardProps {
+  entries: LeaderboardEntry[];
+}
+
+export default function Leaderboard({ entries }: LeaderboardProps) {
+  return (
+    <table className="min-w-full text-left border">
+      <thead>
+        <tr>
+          <th className="p-2 border">User</th>
+          <th className="p-2 border">XP</th>
+        </tr>
+      </thead>
+      <tbody>
+        {entries.map((e) => (
+          <tr key={e.userId}>
+            <td className="p-2 border">{e.displayName}</td>
+            <td className="p-2 border">{e.xp}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/components/ProfileDashboard.tsx
+++ b/components/ProfileDashboard.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+interface ProfileDashboardProps {
+  email: string;
+  xp: number;
+  streak: number;
+}
+
+export default function ProfileDashboard({ email, xp, streak }: ProfileDashboardProps) {
+  return (
+    <div className="space-y-2">
+      <p className="font-semibold">{email}</p>
+      <p>XP: {xp}</p>
+      <p>Streak: {streak} days</p>
+    </div>
+  );
+}

--- a/components/Quiz.tsx
+++ b/components/Quiz.tsx
@@ -1,0 +1,54 @@
+"use client";
+import React, { useState } from "react";
+
+export interface QuizQuestion {
+  id: string;
+  question: string;
+  options: string[];
+  answer: string;
+}
+
+interface QuizProps {
+  questions: QuizQuestion[];
+  onComplete: (score: number) => void;
+}
+
+export default function Quiz({ questions, onComplete }: QuizProps) {
+  const [current, setCurrent] = useState(0);
+  const [correct, setCorrect] = useState(0);
+
+  const handleAnswer = (option: string) => {
+    if (questions[current].answer === option) {
+      setCorrect((c) => c + 1);
+    }
+
+    const next = current + 1;
+    if (next < questions.length) {
+      setCurrent(next);
+    } else {
+      onComplete(correct + (questions[current].answer === option ? 1 : 0));
+    }
+  };
+
+  const q = questions[current];
+
+  return (
+    <div className="space-y-4">
+      <h3>{q.question}</h3>
+      <div className="flex flex-col gap-2">
+        {q.options.map((o) => (
+          <button
+            key={o}
+            onClick={() => handleAnswer(o)}
+            className="p-2 border rounded"
+          >
+            {o}
+          </button>
+        ))}
+      </div>
+      <p className="text-sm text-gray-500">
+        Question {current + 1} of {questions.length}
+      </p>
+    </div>
+  );
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -3,8 +3,7 @@ service cloud.firestore {
   match /databases/{database}/documents {
     // Match any document in the database
     match /{document=**} {
-      allow read, write: if
-          request.auth != null; // Allow read/write if the user is authenticated
+      allow read: if request.auth != null;
     }
 
     // Specific rules for the 'users' collection
@@ -18,21 +17,15 @@ service cloud.firestore {
     // Specific rules for the 'courses' collection and its subcollections
     match /courses/{courseId} {
       allow read: if request.auth != null;
-      allow create: if false; // Courses should be created by admins
-      allow update: if false; // Courses should be updated by admins
-      allow delete: if false; // Courses should be deleted by admins
+      allow create, update, delete: if request.auth.token.admin == true;
 
       match /modules/{moduleId} {
         allow read: if request.auth != null;
-        allow create: if false; // Modules should be created by admins
-        allow update: if false; // Modules should be updated by admins
-        allow delete: if false; // Modules should be deleted by admins
+        allow create, update, delete: if request.auth.token.admin == true;
 
         match /lessons/{lessonId} {
           allow read: if request.auth != null;
-          allow create: if false; // Lessons should be created by admins
-          allow update: if false; // Lessons should be updated by admins
-          allow delete: if false; // Lessons should be deleted by admins
+          allow create, update, delete: if request.auth.token.admin == true;
         }
       }
     }

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -7,6 +7,7 @@ import * as functions from "firebase-functions";
 import { initializeApp } from "firebase-admin/app";
 import { getFirestore } from "firebase-admin/firestore";
 // Import Vertex AI SDK here
+// import { VertexAI } from '@google-cloud/vertexai';
 
 initializeApp();
 const db = getFirestore();
@@ -26,10 +27,11 @@ export const processUploadedContent = functions.storage.object().onFinalize(asyn
     return null;
   }
 
-  // TODO: Download the file and extract text (for PDF/text files).
-  // TODO: Call Vertex AI (Gemini) to process the text and generate lessons/questions.
-  // TODO: Store the generated lessons and questions in Firestore.
-  // TODO: Optionally delete the original file or move it to a processed folder.
+  // Example: Download file, send to Vertex AI to create lessons and questions
+  // const ai = new VertexAI({project: process.env.GCP_PROJECT});
+  // const text = await extractTextFromFile(fileBucket, filePath);
+  // const response = await ai.generateContent({text});
+  // await db.collection('courses').doc(courseId).set(response);
 
   console.log(`Processing file: ${filePath}`);
 

--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -2,6 +2,7 @@ import { initializeApp } from "firebase/app";
 import { getAuth } from "firebase/auth";
 import { getFirestore } from "firebase/firestore";
 import { getFunctions } from "firebase/functions";
+import { getStorage } from "firebase/storage";
 
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
@@ -16,5 +17,6 @@ const app = initializeApp(firebaseConfig);
 const auth = getAuth(app);
 const db = getFirestore(app);
 const functions = getFunctions(app);
+const storage = getStorage(app);
 
-export { auth, db, functions };
+export { app, auth, db, functions, storage };

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -1,10 +1,25 @@
-const AdminDashboard = () => {
+"use client";
+import { useState } from 'react';
+import { getStorage, ref, uploadBytes } from 'firebase/storage';
+import { app } from '../../lib/firebase';
+
+const storage = getStorage(app);
+
+export default function AdminDashboard() {
+  const [file, setFile] = useState<File | null>(null);
+
+  const handleUpload = async () => {
+    if (!file) return;
+    const fileRef = ref(storage, `uploads/${file.name}`);
+    await uploadBytes(fileRef, file);
+    alert('Uploaded');
+  };
+
   return (
     <div>
       <h1>Admin Dashboard</h1>
-      {/* Add content upload and management tools here */}
+      <input type="file" onChange={(e) => setFile(e.target.files?.[0] || null)} />
+      <button onClick={handleUpload}>Upload</button>
     </div>
   );
-};
-
-export default AdminDashboard;
+}

--- a/pages/courses/[courseId]/index.tsx
+++ b/pages/courses/[courseId]/index.tsx
@@ -1,10 +1,20 @@
-const CourseMap = () => {
+import CourseMap, { LessonNode } from '../../../components/CourseMap';
+
+const mockLessons: LessonNode[] = [
+  { id: '1', title: 'Intro', unlocked: true },
+  { id: '2', title: 'Basics', unlocked: false },
+];
+
+export default function CourseMapPage() {
+  const handleSelect = (id: string) => {
+    // TODO: integrate with router
+    console.log('Selected lesson', id);
+  };
+
   return (
     <div>
       <h1>Course Map</h1>
-      {/* Design course map UI here */}
+      <CourseMap lessons={mockLessons} onSelect={handleSelect} />
     </div>
   );
-};
-
-export default CourseMap;
+}

--- a/pages/courses/[courseId]/lessons/[lessonId].tsx
+++ b/pages/courses/[courseId]/lessons/[lessonId].tsx
@@ -1,10 +1,19 @@
-const LessonPage = () => {
+import Quiz, { QuizQuestion } from '../../../../components/Quiz';
+
+const questions: QuizQuestion[] = [
+  { id: 'q1', question: 'Hello in Spanish?', options: ['Hola', 'Adios'], answer: 'Hola' },
+  { id: 'q2', question: 'Thank you in French?', options: ['Merci', 'Gracias'], answer: 'Merci' },
+];
+
+export default function LessonPage() {
+  const handleComplete = (score: number) => {
+    alert(`Score: ${score}/${questions.length}`);
+  };
+
   return (
     <div>
       <h1>Lesson</h1>
-      {/* Display lesson content and quiz components here */}
+      <Quiz questions={questions} onComplete={handleComplete} />
     </div>
   );
-};
-
-export default LessonPage;
+}

--- a/pages/leaderboard.tsx
+++ b/pages/leaderboard.tsx
@@ -1,0 +1,15 @@
+import Leaderboard, { LeaderboardEntry } from '../components/Leaderboard';
+
+const entries: LeaderboardEntry[] = [
+  { userId: '1', displayName: 'Alice', xp: 1200 },
+  { userId: '2', displayName: 'Bob', xp: 950 },
+];
+
+export default function LeaderboardPage() {
+  return (
+    <div>
+      <h1>Leaderboard</h1>
+      <Leaderboard entries={entries} />
+    </div>
+  );
+}

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -1,5 +1,6 @@
 import { useAuthState } from 'react-firebase-hooks/auth';
 import { auth } from '../lib/firebase';
+import ProfileDashboard from '../components/ProfileDashboard';
 
 const Profile = () => {
   const [user, loading, error] = useAuthState(auth);
@@ -19,8 +20,7 @@ const Profile = () => {
   return (
     <div>
       <h1>Profile</h1>
-      <p>Email: {user.email}</p>
-      {/* Add profile details and options here */}
+      <ProfileDashboard email={user.email!} xp={0} streak={0} />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- outline project goals and plan in `blueprint.md`
- add CourseMap, Quiz, Leaderboard and ProfileDashboard components
- stub admin upload dashboard and course/lesson pages
- export storage from Firebase config
- add leaderboard page and update profile page
- tighten Firestore rules with admin role
- provide example Vertex AI Cloud Function

## Testing
- `npm run lint` *(fails: prompts for eslint config)*

------
https://chatgpt.com/codex/tasks/task_e_6887a6dac0a88333a977106dcf953202